### PR TITLE
Add test for healthchecks

### DIFF
--- a/apps/ircbot/app.yaml
+++ b/apps/ircbot/app.yaml
@@ -26,13 +26,7 @@
             "forcePullImage": false
         }
     },
-    "portDefinitions": [
-        {
-            "port": 10005,
-            "protocol": "tcp",
-            "labels": {}
-        }
-    ],
+    "portDefinitions": [],
     "upgradeStrategy": {
         "minimumHealthCapacity": 0,
         "maximumOverCapacity": 0

--- a/apps/ocfweb/worker/app.yaml
+++ b/apps/ocfweb/worker/app.yaml
@@ -29,13 +29,7 @@
     "env": {
         "OCFWEB_TESTING": "0"
     },
-    "portDefinitions": [
-        {
-            "port": 10003,
-            "protocol": "tcp",
-            "labels": {}
-        }
-    ],
+    "portDefinitions": [],
     "maxLaunchDelaySeconds": 3600,
     "backoffFactor": 1.15,
     "backoffSeconds": 1,

--- a/apps/slackbridge/app.yaml
+++ b/apps/slackbridge/app.yaml
@@ -26,13 +26,7 @@
             "forcePullImage": false
         }
     },
-    "portDefinitions": [
-        {
-            "protocol": "tcp",
-            "port": 10006,
-            "labels": {},
-        }
-    ],
+    "portDefinitions": [],
     "maxLaunchDelaySeconds": 3600,
     "backoffFactor": 1.15,
     "backoffSeconds": 1,


### PR DESCRIPTION
This enforces that each port a service defines at least has a healthcheck (though not necessarily that it's a good healthcheck).

I also removed some port definitions from services that don't provide a Docker mapping (meaning they were claiming that as their port to Marathon, but nothing was bound to that port ever). These were just auto-added by the UI.

Here's an example failure:

```
E               AssertionError: No healthcheck for "/ocfweb/worker" port index 0:
E                   {'port': 10003, 'protocol': 'tcp', 'labels': {}}
```