### PR TITLE
Add puppetboard service

### DIFF
--- a/apps/puppetboard/app.yaml
+++ b/apps/puppetboard/app.yaml
@@ -1,0 +1,83 @@
+{
+    "id": "/puppetboard",
+    "cmd": null,
+    "cpus": 0.5,
+    "mem": 1024,
+    "disk": 0,
+    "gpus": 0,
+    "instances": 3,
+    "executor": "",
+    "requirePorts": false,
+    "constraints": [
+        [
+            "secrets",
+            "LIKE",
+            "true"
+        ],
+    ],
+    "acceptedResourceRoles": [
+        "*"
+    ],
+    "container": {
+        "type": "DOCKER",
+        "volumes": [
+            {
+                "containerPath": "/opt/puppetboard/keys",
+                "hostPath": "/opt/share/docker/secrets/puppetboard/keys",
+                "mode": "RO"
+            }
+        ],
+        "docker": {
+            "image": "docker.ocf.berkeley.edu/puppetboard",
+            "network": "BRIDGE",
+            "portMappings": [
+                {
+                    "containerPort": 8080,
+                    "hostPort": 0,
+                    "servicePort": 10009,
+                    "protocol": "tcp",
+                    "name": "main",
+                    "labels": {}
+                }
+            ],
+            "privileged": false,
+            "parameters": [],
+            "forcePullImage": false
+        }
+    },
+    "healthChecks": [
+        {
+            "protocol": "COMMAND",
+            "command": {
+                "value": "test $(curl -s -o /dev/null -w '%{http_code}' -H 'Host: puppet.ocf.berkeley.edu' http://$HOST:$PORT0/) -eq 401",
+            },
+            "delaySeconds": 15,
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3,
+        }
+    ],
+    "labels": {
+        "HAPROXY_GROUP": "lb"
+    },
+    "portDefinitions": [
+        {
+            "port": 10009,
+            "protocol": "tcp",
+            "labels": {}
+        }
+    ],
+    "maxLaunchDelaySeconds": 3600,
+    "backoffFactor": 1.15,
+    "backoffSeconds": 1,
+    "upgradeStrategy": {
+        "minimumHealthCapacity": 1,
+        "maximumOverCapacity": 1,
+    },
+    "killSelection": 'YOUNGEST_FIRST',
+    "unreachableStrategy": {
+        "inactiveAfterSeconds": 300,
+        "expungeAfterSeconds": 600,
+    },
+}


### PR DESCRIPTION
I'm using a old RT-style healthcheck here, so it would be better to use something that actually authenticates with something like the test staff account to check that the service is actually running ok, and not just the nginx authentication in front of it. Something like in 962132bbab276782c24b67f1e477136ff3f285cd and ocf/rt/pull/3 would be good, but for now this works.