### PR TITLE
Added Grafana app

### DIFF
--- a/apps/grafana/app.yaml
+++ b/apps/grafana/app.yaml
@@ -35,7 +35,7 @@
             {
                 "containerPort": 3000,
                 "hostPort": 0,
-                "servicePort": 10006,
+                "servicePort": 10011,
                 "protocol": "tcp",
                 "name": "main",
                 "labels": {}

--- a/apps/grafana/app.yaml
+++ b/apps/grafana/app.yaml
@@ -1,0 +1,91 @@
+{
+    "id": "/grafana",
+    "cmd": null,
+    "cpus": 2,
+    "mem": 2048,
+    "disk": 0,
+    "gpus": 0,
+    "instances": 1,
+    "executor": "",
+    "requirePorts": false,
+    "constraints": [
+        [
+            "secrets",
+            "LIKE",
+            "true"
+        ],
+    ],
+    "acceptedResourceRoles": ['*'],
+    "container": {
+        "type": "DOCKER",
+        "volumes": [
+            {
+                "containerPath": "/etc/secrets",
+                "hostPath": "/opt/share/docker/secrets/grafana",
+                "mode": "RO"
+            }
+        ],
+        "docker": {
+            "image": "docker.ocf.berkeley.edu/grafana",
+            "privileged": false,
+            "parameters": [],
+            "forcePullImage": false
+        },
+        "portMappings": [
+            {
+                "containerPort": 3000,
+                "hostPort": 0,
+                "servicePort": 10006,
+                "protocol": "tcp",
+                "name": "main",
+                "labels": {}
+            }
+        ]
+    },
+    "networks": [
+        {
+            "mode": "container/bridge"
+        }
+    ],
+    "env": {
+        "GF_SERVER_ROOT_URL": "https://grafana.ocf.berkeley.edu/",
+        "GF_DATABASE_TYPE": "mysql",
+        "GF_DATABASE_HOST": "mysql",
+        "GF_DATABASE_NAME": "ocfgrafana",
+        "GF_DATABASE_USER": "ocfgrafana",
+        "GF_SESSION_PROVIDER": "mysql",
+        "GF_SESSION_COOKIE_SECURE": "true",
+
+        "GF_DATABASE_PASSWORD__FILE": "/etc/secrets/mysql-pass",
+        "GF_SECURITY_ADMIN_PASSWORD__FILE": "/etc/secrets/admin-pass",
+        "GF_SESSION_PROVIDER_CONFIG__FILE": "/etc/secrets/provider-config",
+    },
+    "healthChecks": [
+        {
+            "path": "/",
+            "protocol": "MESOS_HTTP",
+            "portIndex": 0,
+            "delaySeconds": 300,
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "ipProtocol": "IPv4",
+        }
+    ],
+    "labels": {
+        "HAPROXY_GROUP": "lb"
+    },
+    "maxLaunchDelaySeconds": 3600,
+    "backoffFactor": 1.15,
+    "backoffSeconds": 1,
+    "upgradeStrategy": {
+        "minimumHealthCapacity": 1,
+        "maximumOverCapacity": 1,
+    },
+    "killSelection": 'YOUNGEST_FIRST',
+    "unreachableStrategy": {
+        "inactiveAfterSeconds": 300,
+        "expungeAfterSeconds": 600,
+    },
+}


### PR DESCRIPTION
This adds the Grafana app to Marathon. Most of the config has been copied from Metabase. See https://github.com/ocf/grafana.