### PR TITLE
Add sourcegraph service

### DIFF
--- a/apps/sourcegraph/app.yaml
+++ b/apps/sourcegraph/app.yaml
@@ -1,0 +1,88 @@
+{
+    "id": "/sourcegraph",
+    "cmd": null,
+    "cpus": 2,
+    "mem": 2048,
+    "disk": 0,
+    "gpus": 0,
+    "instances": 1,
+    "executor": "",
+    "requirePorts": false,
+    "constraints": [
+        [
+            "secrets",
+            "LIKE",
+            "true"
+        ],
+    ],
+    "acceptedResourceRoles": ['*'],
+    "container": {
+        "type": "DOCKER",
+        "volumes": [
+            {
+                "containerPath": "/etc/sourcegraph",
+                "hostPath": "/opt/share/docker/secrets/sourcegraph",
+                "mode": "RW"
+            },
+            {
+                "containerPath": "/var/opt/sourcegraph",
+                "hostPath": "/opt/share/docker/sourcegraph",
+                "mode": "RW"
+            }
+        ],
+        "docker": {
+            "image": "sourcegraph/server:2.11.2",
+            "privileged": false,
+            "parameters": [
+                {
+                    "key": "env-file",
+                    "value": "/opt/share/docker/secrets/sourcegraph/env-file"
+                }
+            ],
+            "forcePullImage": false
+        },
+        "portMappings": [
+            {
+                "containerPort": 7080,
+                "hostPort": 0,
+                "servicePort": 10012,
+                "protocol": "tcp",
+                "name": "main",
+                "labels": {}
+            }
+        ]
+    },
+    "networks": [
+        {
+            "mode": "container/bridge"
+        }
+    ],
+    "healthChecks": [
+        {
+            "path": "/",
+            "protocol": "MESOS_HTTP",
+            "portIndex": 0,
+            "delaySeconds": 15,
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "ipProtocol": "IPv4",
+        }
+    ],
+    "labels": {
+        "HAPROXY_GROUP": "lb"
+    },
+    "maxLaunchDelaySeconds": 3600,
+    "backoffFactor": 1.15,
+    "backoffSeconds": 1,
+    "upgradeStrategy": {
+        "minimumHealthCapacity": 1,
+        "maximumOverCapacity": 1,
+    },
+    "killSelection": 'YOUNGEST_FIRST',
+    "unreachableStrategy": {
+        "inactiveAfterSeconds": 300,
+        "expungeAfterSeconds": 600,
+    },
+}

--- a/tests/sanity_test.py
+++ b/tests/sanity_test.py
@@ -54,7 +54,7 @@ def test_app_docker_image_has_no_tag(app):
     in the service definitions.
     """
     # with some exceptions...
-    if app.id == '/thelounge':
+    if app.id in ['/thelounge', '/sourcegraph']:
         pytest.skip()
 
     image = app.json['container']['docker']['image']


### PR DESCRIPTION
This adds a sourcegraph service (which is already running), but it's definitely best to actually commit the config for it somewhere (and for future version updates, etc.)