### PR TITLE
Add snmp_exporter service

### DIFF
--- a/apps/snmp_exporter/app.yaml
+++ b/apps/snmp_exporter/app.yaml
@@ -1,0 +1,71 @@
+{
+    "id": "/snmp_exporter",
+    "cmd": null,
+    "cpus": 1,
+    "mem": 1024,
+    "disk": 0,
+    "gpus": 0,
+    "instances": 1,
+    "executor": "",
+    "requirePorts": false,
+    "constraints": [
+        [
+            "secrets",
+            "LIKE",
+            "true"
+        ],
+    ],
+    "acceptedResourceRoles": ['*'],
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "docker.ocf.berkeley.edu/snmp_exporter",
+            "privileged": false,
+            "parameters": [],
+            "forcePullImage": false
+        },
+        "portMappings": [
+            {
+                "containerPort": 9116,
+                "hostPort": 0,
+                "servicePort": 10013,
+                "protocol": "tcp",
+                "name": "main",
+                "labels": {}
+            }
+        ]
+    },
+    "networks": [
+        {
+            "mode": "container/bridge"
+        }
+    ],
+    "healthChecks": [
+        {
+            "path": "/",
+            "protocol": "MESOS_HTTP",
+            "portIndex": 0,
+            "delaySeconds": 300,
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "ipProtocol": "IPv4",
+        }
+    ],
+    "labels": {
+        "HAPROXY_GROUP": "lb"
+    },
+    "maxLaunchDelaySeconds": 3600,
+    "backoffFactor": 1.15,
+    "backoffSeconds": 1,
+    "upgradeStrategy": {
+        "minimumHealthCapacity": 1,
+        "maximumOverCapacity": 1,
+    },
+    "killSelection": 'YOUNGEST_FIRST',
+    "unreachableStrategy": {
+        "inactiveAfterSeconds": 300,
+        "expungeAfterSeconds": 600,
+    },
+}

--- a/apps/snmp_exporter/app.yaml
+++ b/apps/snmp_exporter/app.yaml
@@ -2,7 +2,7 @@
     "id": "/snmp_exporter",
     "cmd": null,
     "cpus": 1,
-    "mem": 65,
+    "mem": 64,
     "disk": 0,
     "gpus": 0,
     "instances": 1,

--- a/apps/snmp_exporter/app.yaml
+++ b/apps/snmp_exporter/app.yaml
@@ -2,7 +2,7 @@
     "id": "/snmp_exporter",
     "cmd": null,
     "cpus": 1,
-    "mem": 1024,
+    "mem": 65,
     "disk": 0,
     "gpus": 0,
     "instances": 1,

--- a/apps/snmp_exporter/app.yaml
+++ b/apps/snmp_exporter/app.yaml
@@ -28,7 +28,7 @@
             {
                 "containerPort": 9116,
                 "hostPort": 0,
-                "servicePort": 10013,
+                "servicePort": 10020,
                 "protocol": "tcp",
                 "name": "main",
                 "labels": {}


### PR DESCRIPTION
This adds the snmp_exporter service to Marathon. This is a very minimal services-- doesn't require any secrets, special storage, or configuration (the one configuration file is baked into the Docker image). Is it possible to make this even more minimal?